### PR TITLE
Fixed Typos

### DIFF
--- a/docs/t-sql/language-elements/set-local-variable-transact-sql.md
+++ b/docs/t-sql/language-elements/set-local-variable-transact-sql.md
@@ -103,19 +103,19 @@ SET @local_variable {+= | -= | *= | /= | %= | &= | ^= | |= } expression
   
  += Addition und Zuweisung  
   
- = Subtraktion und Zuweisung  
+ -= Subtraktion und Zuweisung  
   
- * = Multiplikation und Zuweisung  
+ *= Multiplikation und Zuweisung  
   
- / = Division und Zuweisung  
+ /= Division und Zuweisung  
   
- % = Modulo und Zuweisung  
+ %= Modulo und Zuweisung  
   
- &=              Bitweises AND und Zuweisung  
+ &= Bitweises AND und Zuweisung  
   
- ^ = Bitweises XOR und Zuweisung  
+ ^= Bitweises XOR und Zuweisung  
   
- | = Bitweises OR und Zuweisung  
+ |= Bitweises OR und Zuweisung  
   
  *expression*  
  Ist ein beliebiger gültiger [Ausdruck](../../t-sql/language-elements/expressions-transact-sql.md).  


### PR DESCRIPTION
Just fixed some typos in the section 'Verbundzuweisungsoperator:'