### PR TITLE
Update select-group-by-transact-sql.md

### DIFF
--- a/docs/t-sql/queries/select-group-by-transact-sql.md
+++ b/docs/t-sql/queries/select-group-by-transact-sql.md
@@ -449,7 +449,8 @@ SELECT SalesAmount FROM FactInternetSales GROUP BY SalesAmount, SalesAmount*1.10
 -- Uses AdventureWorks  
   
 SELECT OrderDateKey, DueDateKey, SUM(SalesAmount) AS TotalSales   
-FROM FactInternetSalesGROUP BY OrderDateKey, DueDateKey   
+FROM FactInternetSales
+GROUP BY OrderDateKey, DueDateKey   
 ORDER BY OrderDateKey;  
 ```  
   


### PR DESCRIPTION
fehlender Space/Zeilenumbruch im SQL Beispiel (da alle anderen Beispiele GROUP BY in seperater Zeile haben, dieses auch auf Zeilenumbruch angepasst)