### PR TITLE
fixed translation de-DE

### DIFF
--- a/docs/relational-databases/maintenance-plans/options-in-the-back-up-database-task-for-maintenance-plan.md
+++ b/docs/relational-databases/maintenance-plans/options-in-the-back-up-database-task-for-maintenance-plan.md
@@ -32,7 +32,7 @@ ms.locfileid: "47647378"
   
 -   [Erstellen eines Wartungsplans](../../relational-databases/maintenance-plans/create-a-maintenance-plan.md)  
   
-## <a name="options"></a>Tastatur  
+## <a name="options"></a>Optionen  
  **Verbindung**  
  Wählen Sie die Serververbindung aus, die bei der Ausführung dieses Tasks verwendet werden soll.  
   


### PR DESCRIPTION
 options =! tastatur, correct is 'Optionen' or 'Auswahlmöglichkeiten'